### PR TITLE
Release 2.6.1-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "xrplmeta",
-	"version": "2.6.0-alpha",
+	"version": "2.6.1-alpha",
 	"type": "module",
 	"scripts": {
 		"start": "node src/run.js",

--- a/src/crawl/crawlers/xumm.js
+++ b/src/crawl/crawlers/xumm.js
@@ -61,7 +61,7 @@ async function crawlAssets({ ctx, fetch, interval }){
 					throw new Error(`malformed response`)
 				}
 
-				log.info(`got ${Object.values(data.details).length} issuers`)
+				log.info(`got ${Object.values(data.details).length} curated assets`)
 
 				for(let issuer of Object.values(data.details)){
 					for(let currency of Object.values(issuer.currencies)){
@@ -73,7 +73,12 @@ async function crawlAssets({ ctx, fetch, interval }){
 							props: {
 								name: issuer.name,
 								domain: issuer.domain,
-								icon: issuer.avatar
+								icon: issuer.avatar,
+								trust_level: (
+									issuer.info_source.type === 'native'
+										? (issuer.shortlist ? 3 : 2)
+										: 1
+								)
 							},
 							source: 'xumm'
 						})
@@ -89,9 +94,11 @@ async function crawlAssets({ ctx, fetch, interval }){
 							props: {
 								name: currency.name,
 								icon: currency.avatar,
-								trust_level: currency.shortlist
-									? 3
-									: 1
+								trust_level: (
+									currency.info_source.type === 'native'
+										? (currency.shortlist ? 3 : 2)
+										: 1
+								)
 							},
 							source: 'xumm'
 						})

--- a/src/etl/state/scopes/accounts.js
+++ b/src/etl/state/scopes/accounts.js
@@ -1,6 +1,7 @@
 import { div } from '@xrplkit/xfl'
 import { isBlackholed } from '../../../xrpl/blackhole.js'
 import { writeBalance } from '../../../db/helpers/balances.js'
+import { updateCacheForAccountProps } from '../../../db/helpers/cache.js'
 
 
 export function parse({ entry }){
@@ -26,6 +27,9 @@ export function diff({ ctx, previous, final }){
 				? { address }
 				: meta
 		})
+
+		if(final?.Domain != previous?.Domain)
+			updateCacheForAccountProps({ ctx, account: final })
 	}else{
 		var { id } = ctx.db.accounts.createOne({ 
 			data: {


### PR DESCRIPTION
Fixes minor issues that were overlooked on 2.6.0-alpha:

- An AccountSet for domains did not trigger a token cache update.
- Handling protocols in the domain field.
- Incorrect trust levels derived from Xumm's curated asset list.