### PR TITLE
Release 2.6.2-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "xrplmeta",
-	"version": "2.6.1-alpha",
+	"version": "2.6.2-alpha",
 	"type": "module",
 	"scripts": {
 		"start": "node src/run.js",

--- a/src/db/helpers/props.js
+++ b/src/db/helpers/props.js
@@ -135,7 +135,6 @@ export function writeAccountProps({ ctx, account, props, source }){
 
 export function reduceProps({ props, expand, sourceRanking }){
 	let data = {}
-	let sources = {}
 	let sourceRanks = {}
 	let weblinks = []
 
@@ -156,7 +155,7 @@ export function reduceProps({ props, expand, sourceRanking }){
 			if(key === 'weblinks'){
 				weblinks.push({ links: value, rank })
 			}else{
-				if(!sources[key] || sourceRanks[key] > rank){
+				if(!sourceRanks[key] || sourceRanks[key] > rank){
 					data[key] = value
 					sourceRanks[key] = rank
 				}


### PR DESCRIPTION
This fixes a minor bug that caused the meta properties returned from the API to not be ranked correctly. For example, the Twitter metadata of a token took precedence over its own xrp-ledger.toml metadata.