### PR TITLE
fix: add shebang to run.js

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -1,3 +1,5 @@
+#!node
+
 import minimist from 'minimist'
 import log from '@mwni/log'
 import { find as findConfig } from './lib/config.js'


### PR DESCRIPTION
The lack of shebang prevented the server from being run when using xrplmeta globally installed.