### PR TITLE
Set v1 endpoint removal date to 01-01-2027

### DIFF
--- a/src/srv/warnings/warning.js
+++ b/src/srv/warnings/warning.js
@@ -3,7 +3,7 @@ export function addTokenV1DeprecationWarning(){
         let warnings = response.warnings || []
         const tokenV1DeprecationWarning = {
             id: 'token_api_deprecation',
-            message: 'token endpoint is being deprecated and will be removed on MM-DD-YYYY. Prefer HTTP /v2/token endpoint or WebSocket token command with api_version: 2 instead'
+            message: 'token endpoint is being deprecated and will be removed on 01-01-2027. Prefer HTTP /v2/token endpoint or WebSocket token command with api_version: 2 instead'
         }
         return {...response, warnings: [...warnings, tokenV1DeprecationWarning]}
     }
@@ -14,7 +14,7 @@ export function addTokensV1DeprecationWarning(){
         let warnings = response.warnings || []
         const tokensV1DeprecationWarning = {
             id: 'tokens_api_deprecation',
-            message: 'tokens endpoint is being deprecated and will be removed on MM-DD-YYYY. Prefer HTTP /v2/tokens endpoint or WebSocket tokens command with api_version: 2 instead'
+            message: 'tokens endpoint is being deprecated and will be removed on 01-01-2027. Prefer HTTP /v2/tokens endpoint or WebSocket tokens command with api_version: 2 instead'
         }
         return {...response, warnings: [...warnings, tokensV1DeprecationWarning]}
     }
@@ -25,7 +25,7 @@ export function addTokenHoldersV1DeprecationWarning(){
         let warnings = response.warnings || []
         const tokenHoldersV1DeprecationWarning = {
             id: 'token_holders_api_deprecation',
-            message: 'token/:token/holders endpoint is being deprecated and will be removed on MM-DD-YYYY. Prefer HTTP /v2/token/:token/holders endpoint or WebSocket token_holders command with api_version: 2 instead'
+            message: 'token/:token/holders endpoint is being deprecated and will be removed on 01-01-2027. Prefer HTTP /v2/token/:token/holders endpoint or WebSocket token_holders command with api_version: 2 instead'
         }
         return {...response, warnings: [...warnings, tokenHoldersV1DeprecationWarning]}
     }
@@ -36,7 +36,7 @@ export function addServerInfoV1DeprecationWarning(){
         let warnings = response.warnings || []
         const serverInfoV1DeprecationWarning = {
             id: 'server_api_deprecation',
-            message: 'server endpoint is being deprecated and will be removed on MM-DD-YYYY. Prefer HTTP /v2/server endpoint or WebSocket server_info command with api_version: 2 instead'
+            message: 'server endpoint is being deprecated and will be removed on 01-01-2027. Prefer HTTP /v2/server endpoint or WebSocket server_info command with api_version: 2 instead'
         }
         return {...response, warnings: [...warnings, serverInfoV1DeprecationWarning]}
     }
@@ -47,7 +47,7 @@ export function addLedgerV1DeprecationWarning(){
         let warnings = response.warnings || []
         const ledgerV1DeprecationWarning = {
             id: 'ledger_api_deprecation',
-            message: 'ledger endpoint is being deprecated and will be removed on MM-DD-YYYY. Prefer HTTP /v2/ledger endpoint or WebSocket ledger command with api_version: 2 instead'
+            message: 'ledger endpoint is being deprecated and will be removed on 01-01-2027. Prefer HTTP /v2/ledger endpoint or WebSocket ledger command with api_version: 2 instead'
         }
         return {...response, warnings: [...warnings, ledgerV1DeprecationWarning]}
     }
@@ -58,7 +58,7 @@ export function addTokenExchangesV1DeprecationWarning(){
         let warnings = response.warnings || []
         const tokenExchangesV1DeprecationWarning = {
             id: 'token_exchanges_api_deprecation',
-            message: 'tokens/exchanges endpoint is being deprecated and will be removed on MM-DD-YYYY. Prefer HTTP /v2/tokens/exchanges endpoint or WebSocket token_exchanges command with api_version: 2 instead'
+            message: 'tokens/exchanges endpoint is being deprecated and will be removed on 01-01-2027. Prefer HTTP /v2/tokens/exchanges endpoint or WebSocket token_exchanges command with api_version: 2 instead'
         }
         return {...response, warnings: [...warnings, tokenExchangesV1DeprecationWarning]}
     }


### PR DESCRIPTION
Replaces the `MM-DD-YYYY` placeholder in v1 API removal warning messages with a concrete removal date of `01-01-2027`.